### PR TITLE
Define tables of chat-space's DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 |image|text||
 |text|text||
 |user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group
@@ -26,10 +27,11 @@
 ## groups table
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false|
+|name|sring|null: false|
 ### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users
+- has_many :messages
 
 ## groups_usersテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -1,24 +1,41 @@
 # README
+# CHAT SPACE DB
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## users table
 
-Things you may want to cover:
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|name|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :users, through: :groups_users
 
-* Ruby version
+## messages table
+|Column|Type|Options|
+|------|----|-------|
+|image|text||
+|text|text||
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
 
-* System dependencies
+## groups table
+|Column|Type|Options|
+|------|----|-------|
+|name|text|null: false|
+### Association
+- has_many :groups_users
+- has_many :users, through: :groups_users
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
# What
- README.mdにchat-spaceアプリのDB設計を記載

# Why
- アプリ作成に取り掛かる前にDB設計をすることで作成指針を明確化し、手戻りを防止する