### PR TITLE
Implement chat group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ gem "font-awesome-sass"
 group :production do
   gem 'unicorn'
 end
+
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.1)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -109,6 +110,11 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.13.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.4)
     rack (2.2.2)
     rack-test (0.6.3)
@@ -223,6 +229,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_racer
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   rspec

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "modules/flash";
+@import "modules/group";
 
 .wrapper{
   height: 100vh;

--- a/app/assets/stylesheets/modules/group.scss
+++ b/app/assets/stylesheets/modules/group.scss
@@ -1,0 +1,107 @@
+h1 {
+  letter-spacing: 2px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+h2 {
+  margin-bottom: 10px;
+  color: #f05050;
+  font-size: 14px;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  margin: 0;
+  padding: 0;
+  font-size: 13px;
+}
+
+
+
+.chat-group-form {
+  width: 980px;
+  margin: 60px auto;
+  padding: 40px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+  &__errors {
+    margin: 30px 0;
+    padding: 20px 40px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    text-align: center;
+  }
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+  &__action-btn {
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+  &__field {
+    margin-top: 30px;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+    &--left {
+      float: left;
+      width: 30%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
+    &--right {
+      float: right;
+      width: 70%;
+    }
+  }
+}
+
+.chat-group-user {
+  padding: 0 15px;
+  line-height: 50px;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
+  }
+  &__name {
+    float: left;
+  }
+  &__btn {
+    float: right;
+    display: inline-block;
+    cursor: pointer;
+    &--add {
+      color: #38aef0;
+    }
+    &--remove {
+      color: #f05050;
+    }
+  }
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,7 @@
+class GroupsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,7 +1,19 @@
 class GroupsController < ApplicationController
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name , user_ids:[])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,8 @@
 class GroupsController < ApplicationController
+  def index
+    @groups = Group.includes(:users).all
+  end
+
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,6 +10,20 @@ class GroupsController < ApplicationController
       redirect_to root_path, notice: 'グループを作成しました'
     else
       render :new
+    end
+  end
+
+  def edit
+    @group = Group.find(params[:id])
+  end
+
+  def update
+    group = Group.find(params[:id])
+    if group.update(group_params)
+      redirect_to root_path, notice: 'グループを更新しました'
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,5 @@
+class Group < ApplicationRecord
+  has_many :group_users
+  has_many :users, through: :group_users
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true, uniqueness: true
+  has_many :group_users
+  has_many :groups, through: :group_users
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,20 @@
+= form_for group do |f|
+  .chat-group-from__errors
+    %h2 10 %errors!
+    %ul
+      %li input name please
+  .chat-group-from__field
+    .chat-group-form__field--left
+    = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+    = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-from__field.clearfix
+  .chat-group-from__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+  .chat-group-from__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,8 +1,9 @@
 = form_for group do |f|
   .chat-group-from__errors
-    %h2 10 %errors!
+    %h2= "#{group.errors.full_messages.count}件のエラーが発生しました"
     %ul
-      %li input name please
+      - group.errors.full_messages.each do |message|
+        %li= message
   .chat-group-from__field
     .chat-group-form__field--left
     = f.label :name, class: 'chat-group-form__label'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,5 @@
+=form_for @group do |f|
+  = @group.name
+  = f.text_field :name, class: "chat-group-form__input", placeholder: "新グループ名を入力してください"
+  = f.collection_check_boxes :user_ids, User.all, :id, :name
+  = f.submit "Update", class: "chat-group-form__action-btn"

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,5 +1,3 @@
-=form_for @group do |f|
-  = @group.name
-  = f.text_field :name, class: "chat-group-form__input", placeholder: "新グループ名を入力してください"
-  = f.collection_check_boxes :user_ids, User.all, :id, :name
-  = f.submit "Update", class: "chat-group-form__action-btn"
+.chat-group-form
+  %h1 チャットグループ編集
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,2 @@
+.wrapper
+  = render 'messages/side_bar'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,4 +1,3 @@
-=form_for @group do |f|
-  = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
-  = f.collection_check_boxes :user_ids, User.all, :id, :name
-  = f.submit "Save", class: "chat-group-form__action-btn"
+.chat-group-form
+  %h1 新規チャットグループ
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,1 +1,4 @@
-newgroup!
+=form_for @group do |f|
+  = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+  = f.collection_check_boxes :user_ids, User.all, :id, :name
+  = f.submit "Save", class: "chat-group-form__action-btn"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,1 @@
+newgroup!

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,7 +2,7 @@
   .chat-main__group-info
     .chat-main__group-info__left-box
       %h1.chat-main__group-info__left-box__current-group
-        test
+        test_group
       %ul.chat-main__group-info__left-box__member-list
         Member:
         %li

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -5,7 +5,7 @@
         = current_user.name
       %ul.side-bar__user-name__name-icons__icons
         %li
-          = link_to "" , class: "side-bar__user-name__name-icons__icons__edit" do
+          = link_to new_group_path , class: "side-bar__user-name__name-icons__icons__edit" do
             = icon('far', 'edit')
         %li
           = link_to edit_user_registration_path, class: "side-bar__user-name__name-icons__icons__config" do

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -11,7 +11,10 @@
           = link_to edit_user_registration_path, class: "side-bar__user-name__name-icons__icons__config" do
             = icon('fas', 'cog')
   .side-bar__group-list
-    .side-bar__group-list__group-name
-      techcamp
-    .side-bar__group-list__last-message
-      ok, baby
+    - @groups.each do |g|
+      - g.users.each do |user|
+        - if user_signed_in? && user.id == current_user.id
+          .side-bar__group-list__group-name
+            = g.name
+          .side-bar__group-list__last-message
+            test message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "messages#index"
   resources :users, only: [:edit, :update]
+  resources :groups, only: [:new, :create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "messages#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create]
+  resources :groups, only: [:new, :create, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root "messages#index"
+  root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:new, :create, :edit, :update]
+  resources :groups, only: [:index, :new, :create, :edit, :update]
 end

--- a/db/migrate/20200421140317_create_groups.rb
+++ b/db/migrate/20200421140317_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.index :name, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200421140335_create_group_users.rb
+++ b/db/migrate/20200421140335_create_group_users.rb
@@ -1,0 +1,9 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :group_users do |t|
+      t.references :user, foreign_key: true
+      t.references :group, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200420141457) do
+ActiveRecord::Schema.define(version: 20200421140335) do
+
+  create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "user_id"
+    t.integer  "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_users_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_group_users_on_user_id", using: :btree
+  end
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false
@@ -26,4 +42,6 @@ ActiveRecord::Schema.define(version: 20200420141457) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
 end


### PR DESCRIPTION
# What
- create group table with name column
- add routing to index/new/create/edit/update actions in message_controller.rb
- arrange views and links. new/create of a group is accessed by 'config' icon in the side-bar header
- edit/update of a group is accessed by 'pen' icon in the side-bar
- side-bar shows group names to which the current_user belongs.

# Why
- 'group' is important feature in the chat-space app.
- group enables users to create a group of users where only registered members can have talks with each other.